### PR TITLE
Ignore other kustomization.yaml and github world files

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -30,7 +30,7 @@ MANIFEST_YAML="${TMP}/manifest.yaml"
 trap "rm -rf ${TMP} kustomization.yaml" EXIT
 
 echo "Finding resources in ${PWD}"
-RESOURCES=$(find . -path '*.yaml' | grep -v 'kustomization.yaml' | grep -v '.github' | paste -s -d ',' -)
+RESOURCES=$(find . -path '*.yaml' | grep -v 'kustomization.yaml' | grep -v '/.github/' | paste -s -d ',' -)
 
 echo "Generating kustomization.yaml"
 kustomize create --resources "${RESOURCES}"

--- a/validate.sh
+++ b/validate.sh
@@ -30,7 +30,7 @@ MANIFEST_YAML="${TMP}/manifest.yaml"
 trap "rm -rf ${TMP} kustomization.yaml" EXIT
 
 echo "Finding resources in ${PWD}"
-RESOURCES=$(find . -path '*.yaml' | paste -s -d ',' -)
+RESOURCES=$(find . -path '*.yaml' | grep -v 'kustomization.yaml' | grep -v '.github' | paste -s -d ',' -)
 
 echo "Generating kustomization.yaml"
 kustomize create --resources "${RESOURCES}"


### PR DESCRIPTION
### Description

When we added the `kustomization.yaml` file generated by Flux, our CI started failing with the following error:

```
Error: accumulating resources: accumulation err='accumulating resources from './flux-system/kustomization.yaml': missing metadata.name in object {{kustomize.config.k8s.io/v1beta1 Kustomization} {{ } map[] map[]}}': must build at directory: '/github/workspace/deploy/flux-system/kustomization.yaml': file is not directory
```

Testing this locally I've found that it is because when building with kustomize, no other `kustomization.yaml` should be included, but the `find` command was too broad including all `yaml` files, so I'm adding an exclusion for `kustomization.yaml` files and files under the `.github`.